### PR TITLE
CDLD-61386: Migrate to new Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,12 @@
+name: 👨‍🔧 Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - timezone: Europe/Warsaw
+      cron: "0 0,2,4 * * 1-5"
+
+jobs:
+  renovate:
+    uses: cdqag/renovate/.github/workflows/run.yaml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates the repository to the new Renovate workflow. Please review. Please note that schedule and automerge has been removed, as now schedule is defined in the workflow. Renovate will run according to the new schedule.